### PR TITLE
Add content script for job site overlay injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /apps/web/node_modules
 /packages/shared/node_modules
 /apps/extension/node_modules
+/apps/extension/dist
 
 # testing
 /coverage

--- a/apps/extension/dist/manifest.json
+++ b/apps/extension/dist/manifest.json
@@ -20,5 +20,17 @@
     "16": "assets/icon16.png",
     "48": "assets/icon48.png",
     "128": "assets/icon128.png"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.linkedin.com/*jobs*",
+        "*://*.indeed.com/viewjob*",
+        "*://*.indeed.com/job*",
+        "*://*.glassdoor.com/job-details*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -1,0 +1,84 @@
+import { detectSite } from "./siteDetection";
+import { injectOverlay } from "./overlay";
+
+console.log("AppliStash content script loaded!");
+
+// Function to handle the injection of the overlay
+function handleOverlayInjection() {
+  console.log(
+    "AppliStash: Handling overlay injection for URL:",
+    window.location.href
+  );
+
+  // Detect which job site we're on
+  const site = detectSite(window.location.href);
+
+  if (site) {
+    console.log(
+      `AppliStash: Detected job site: ${site.name}`
+    );
+
+    // Get the current user from Chrome storage
+    chrome.storage.local.get(["user"], (result) => {
+      if (result.user) {
+        console.log(
+          "AppliStash: Found user in storage",
+          result.user
+        );
+        // User is logged in, inject the overlay
+        injectOverlay(site, result.user);
+      } else {
+        console.log(
+          "AppliStash: User not found in storage, using test user"
+        );
+        // For testing purposes, create a mock user
+        const testUser = {
+          name: "Test User",
+          email: "test@example.com",
+        };
+
+        // Save the test user to storage for future use
+        chrome.storage.local.set({ user: testUser }, () => {
+          console.log(
+            "AppliStash: Saved test user to storage"
+          );
+        });
+
+        // Inject the overlay with the test user
+        injectOverlay(site, testUser);
+      }
+    });
+  } else {
+    console.log("AppliStash: Not a supported job site");
+  }
+}
+
+// Run the injection immediately (don't wait for page load)
+handleOverlayInjection();
+
+// Also wait for the DOM to be fully loaded
+window.addEventListener("load", () => {
+  console.log(
+    "AppliStash: Page loaded, checking if we should inject overlay again"
+  );
+  handleOverlayInjection();
+});
+
+// LinkedIn has a single-page application architecture, so we need to listen for URL changes
+let lastUrl = window.location.href;
+const observer = new MutationObserver(() => {
+  const currentUrl = window.location.href;
+  if (currentUrl !== lastUrl) {
+    lastUrl = currentUrl;
+    console.log("AppliStash: URL changed to", currentUrl);
+
+    // Give the page a moment to update its content
+    setTimeout(handleOverlayInjection, 1000);
+  }
+});
+
+// Start observing
+observer.observe(document, {
+  subtree: true,
+  childList: true,
+});

--- a/apps/extension/src/content/overlay.ts
+++ b/apps/extension/src/content/overlay.ts
@@ -1,0 +1,170 @@
+import { JobSite } from "./siteDetection";
+import { extractJobData } from "./sites/dataExtraction";
+import { createOverlayUI } from "./ui";
+
+export interface User {
+  email: string;
+  name: string;
+  token?: string;
+}
+
+export interface JobData {
+  title: string;
+  company: string;
+  location: string;
+  description: string;
+  url: string;
+  source: string;
+}
+
+// API Base URL
+const API_BASE_URL = "http://localhost:3000"; // Change to your actual Next.js app URL
+
+/**
+ * Injects the overlay UI into the job site
+ */
+export function injectOverlay(
+  site: JobSite,
+  user: User
+): void {
+  // Extract job data from the page
+  const jobData = extractJobData(site);
+
+  console.log("AppliStash: Extracted job data:", jobData);
+
+  if (!jobData) {
+    console.error(
+      "AppliStash: Could not extract job data from page"
+    );
+    return;
+  }
+
+  // Always inject directly into the body for maximum visibility
+  console.log("AppliStash: Creating overlay UI");
+
+  // Create the overlay UI
+  const overlayElement = createOverlayUI(
+    jobData,
+    user,
+    (applicationData: JobData) => {
+      saveApplication(applicationData, user);
+    }
+  );
+
+  // Force the overlay to be visible by setting these properties
+  overlayElement.style.display = "block";
+  overlayElement.style.visibility = "visible";
+  overlayElement.style.opacity = "1";
+
+  // Remove any existing overlays first to avoid duplicates
+  const existingOverlays = document.querySelectorAll(
+    ".appli-stash-overlay"
+  );
+  existingOverlays.forEach((overlay) => {
+    if (overlay.parentElement) {
+      overlay.parentElement.removeChild(overlay);
+    }
+  });
+
+  console.log(
+    "AppliStash: Injecting overlay into document.body"
+  );
+
+  // Always inject directly into the document body for maximum visibility
+  document.body.appendChild(overlayElement);
+
+  // Show a console message to confirm injection
+  console.log("AppliStash: Overlay injected successfully!");
+}
+
+/**
+ * Sends the job data to our API to save it as an application
+ */
+async function saveApplication(
+  jobData: JobData,
+  user: User
+): Promise<void> {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/api/application`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jobTitle: jobData.title,
+          company: jobData.company,
+          location: jobData.location,
+          description: jobData.description,
+          sourceUrl: jobData.url,
+          source: jobData.source,
+          status: "applied",
+        }),
+        credentials: "include",
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to save application");
+    }
+
+    const data = await response.json();
+    console.log(
+      "AppliStash: Successfully saved application",
+      data
+    );
+
+    // Show a success message
+    showNotification(
+      "Success",
+      "Application saved to AppliStash!"
+    );
+  } catch (error) {
+    console.error(
+      "AppliStash: Error saving application",
+      error
+    );
+    showNotification(
+      "Error",
+      "Failed to save application. Please try again."
+    );
+  }
+}
+
+/**
+ * Shows a notification to the user
+ */
+function showNotification(
+  title: string,
+  message: string
+): void {
+  // Create notification element
+  const notification = document.createElement("div");
+  notification.className = "appli-stash-notification";
+  notification.innerHTML = `
+    <div class="appli-stash-notification-title">${title}</div>
+    <div class="appli-stash-notification-message">${message}</div>
+  `;
+
+  // Add styles
+  notification.style.position = "fixed";
+  notification.style.bottom = "20px";
+  notification.style.right = "20px";
+  notification.style.backgroundColor =
+    title === "Success" ? "#4CAF50" : "#F44336";
+  notification.style.color = "white";
+  notification.style.padding = "15px";
+  notification.style.borderRadius = "5px";
+  notification.style.zIndex = "10000";
+  notification.style.boxShadow =
+    "0 2px 5px rgba(0,0,0,0.3)";
+
+  // Add to page
+  document.body.appendChild(notification);
+
+  // Remove after 3 seconds
+  setTimeout(() => {
+    document.body.removeChild(notification);
+  }, 3000);
+}

--- a/apps/extension/src/content/siteDetection.ts
+++ b/apps/extension/src/content/siteDetection.ts
@@ -1,0 +1,62 @@
+export interface JobSite {
+  name: string;
+  hostname: string;
+  pattern: RegExp;
+  selectors: {
+    jobTitle?: string;
+    company?: string;
+    location?: string;
+    description?: string;
+    applyButton?: string;
+    container?: string;
+  };
+}
+
+// Define the job sites we support
+export const jobSites: JobSite[] = [
+  {
+    name: "LinkedIn",
+    hostname: "linkedin.com",
+    pattern:
+      /linkedin\.com\/jobs\/(view|collections|search|currentJob)/,
+    selectors: {
+      jobTitle:
+        ".job-details-jobs-unified-top-card__job-title, .jobs-unified-top-card__job-title, .jobs-unified-top-card__job-title-heading",
+      company:
+        ".job-details-jobs-unified-top-card__company-name, .jobs-unified-top-card__company-name, .jobs-unified-top-card__subtitle-primary-grouping .app-aware-link",
+      location:
+        ".job-details-jobs-unified-top-card__bullet, .jobs-unified-top-card__bullet, .jobs-unified-top-card__subtitle-primary-grouping .job-card-container__metadata-item",
+      description:
+        ".jobs-description__content, .jobs-description, .jobs-box__html-content",
+      applyButton: ".jobs-apply-button",
+      container: "body",
+    },
+  },
+  {
+    name: "Indeed",
+    hostname: "indeed.com",
+    pattern: /indeed\.com\/viewjob|indeed\.com\/job\//,
+    selectors: {
+      jobTitle: ".jobsearch-JobInfoHeader-title",
+      company:
+        ".jobsearch-CompanyInfoContainer .jobsearch-InlineCompanyRating div:first-child",
+      location:
+        ".jobsearch-JobInfoHeader-subtitle .jobsearch-JobInfoHeader-locationText",
+      description: "#jobDescriptionText",
+      applyButton: ".jobsearch-IndeedApplyButton-newDesign",
+      container: ".jobsearch-ViewJobLayout-innerContent",
+    },
+  },
+];
+
+/**
+ * Detects which job site we're currently on
+ */
+export function detectSite(url: string): JobSite | null {
+  for (const site of jobSites) {
+    if (site.pattern.test(url)) {
+      return site;
+    }
+  }
+  return null;
+}

--- a/apps/extension/src/content/sites/dataExtraction.ts
+++ b/apps/extension/src/content/sites/dataExtraction.ts
@@ -1,0 +1,345 @@
+import { JobSite } from "../siteDetection";
+import { JobData } from "../overlay";
+
+/**
+ * Extracts job data from a job listing page based on the site selectors
+ */
+export function extractJobData(
+  site: JobSite
+): JobData | null {
+  try {
+    // Special handling for LinkedIn collections/search pages
+    if (
+      site.name === "LinkedIn" &&
+      window.location.href.includes("/jobs/collections/")
+    ) {
+      return extractLinkedInJobCardData();
+    }
+
+    // Get the job title
+    const titleElement = document.querySelector(
+      site.selectors.jobTitle || ""
+    );
+    const title = titleElement
+      ? titleElement.textContent?.trim() || ""
+      : "";
+
+    // Get the company name
+    const companyElement = document.querySelector(
+      site.selectors.company || ""
+    );
+    const company = companyElement
+      ? companyElement.textContent?.trim() || ""
+      : "";
+
+    // Get the location
+    const locationElement = document.querySelector(
+      site.selectors.location || ""
+    );
+    const location = locationElement
+      ? locationElement.textContent?.trim() || ""
+      : "";
+
+    // Get the job description
+    const descriptionElement = document.querySelector(
+      site.selectors.description || ""
+    );
+    const description = descriptionElement
+      ? descriptionElement.textContent?.trim() || ""
+      : "";
+
+    // Get the current URL
+    const url = window.location.href;
+
+    if (!title || !company) {
+      console.error(
+        "AppliStash: Could not extract required job data (title or company)"
+      );
+      return null;
+    }
+
+    return {
+      title,
+      company,
+      location,
+      description,
+      url,
+      source: site.name,
+    };
+  } catch (error) {
+    console.error(
+      "AppliStash: Error extracting job data",
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Function to extract LinkedIn job data with specific handling
+ */
+/**
+ * Extract data from LinkedIn job cards on search/collection pages
+ */
+export function extractLinkedInJobCardData(): JobData | null {
+  try {
+    console.log(
+      "AppliStash: Attempting to extract job card data"
+    );
+
+    // Look for the selected job card (the one that's highlighted)
+    const selectedCard = document.querySelector(
+      ".job-card-container--selected"
+    );
+
+    if (!selectedCard) {
+      console.log("AppliStash: No selected job card found");
+      // Find the first job card as fallback
+      const firstCard = document.querySelector(
+        ".job-card-container"
+      );
+
+      if (!firstCard) {
+        console.log(
+          "AppliStash: No job cards found at all"
+        );
+        return null;
+      }
+
+      console.log(
+        "AppliStash: Using first job card instead"
+      );
+      return extractDataFromJobCard(
+        firstCard as HTMLElement
+      );
+    }
+
+    return extractDataFromJobCard(
+      selectedCard as HTMLElement
+    );
+  } catch (error) {
+    console.error(
+      "AppliStash: Error extracting LinkedIn job card data",
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Extract data from a specific LinkedIn job card element
+ */
+function extractDataFromJobCard(
+  card: HTMLElement
+): JobData | null {
+  const titleElement = card.querySelector(
+    ".job-card-list__title"
+  );
+  const companyElement = card.querySelector(
+    ".job-card-container__company-name"
+  );
+  const locationElement = card.querySelector(
+    ".job-card-container__metadata-item"
+  );
+
+  // For description, we might not have it in the card
+  // Try to get it from the job details panel if it exists
+  const descriptionElement = document.querySelector(
+    ".jobs-description"
+  );
+
+  const title = titleElement
+    ? titleElement.textContent?.trim() || ""
+    : "";
+  const company = companyElement
+    ? companyElement.textContent?.trim() || ""
+    : "";
+  const location = locationElement
+    ? locationElement.textContent?.trim() || ""
+    : "";
+  const description = descriptionElement
+    ? descriptionElement.textContent?.trim() || ""
+    : "No description available";
+
+  // Get URL - if it's a job card, try to get the actual job link
+  let url = window.location.href;
+  const linkElement = card.querySelector(
+    "a.job-card-container__link"
+  );
+  if (linkElement && linkElement.getAttribute("href")) {
+    url = new URL(
+      linkElement.getAttribute("href") as string,
+      window.location.origin
+    ).href;
+  }
+
+  if (!title || !company) {
+    console.log(
+      "AppliStash: Missing required job data from card",
+      { title, company }
+    );
+    return null;
+  }
+
+  return {
+    title,
+    company,
+    location,
+    description,
+    url,
+    source: "LinkedIn",
+  };
+}
+
+export function extractLinkedInJobData(): JobData | null {
+  try {
+    console.log("AppliStash: Extracting LinkedIn job data");
+
+    // LinkedIn specific selectors - try multiple variations for different page layouts
+    const titleElement = document.querySelector(
+      ".job-details-jobs-unified-top-card__job-title, .jobs-unified-top-card__job-title, .jobs-unified-top-card__job-title-heading"
+    );
+    const companyElement = document.querySelector(
+      ".job-details-jobs-unified-top-card__company-name, .jobs-unified-top-card__company-name, .jobs-unified-top-card__subtitle-primary-grouping .app-aware-link"
+    );
+    const locationElement = document.querySelector(
+      ".job-details-jobs-unified-top-card__bullet, .jobs-unified-top-card__bullet, .jobs-unified-top-card__subtitle-primary-grouping .job-card-container__metadata-item"
+    );
+    const descriptionElement = document.querySelector(
+      ".jobs-description__content, .jobs-description, .jobs-box__html-content"
+    );
+
+    console.log("AppliStash: Found elements", {
+      title: titleElement?.textContent,
+      company: companyElement?.textContent,
+      location: locationElement?.textContent,
+      description: descriptionElement ? "Yes" : "No",
+    });
+
+    const title = titleElement
+      ? titleElement.textContent?.trim() || ""
+      : "";
+    const company = companyElement
+      ? companyElement.textContent?.trim() || ""
+      : "";
+    const location = locationElement
+      ? locationElement.textContent?.trim() || ""
+      : "";
+    const description = descriptionElement
+      ? descriptionElement.textContent?.trim() || ""
+      : "";
+    const url = window.location.href;
+
+    console.log("AppliStash: Extracted job data", {
+      title,
+      company,
+      location,
+      descriptionLength: description.length,
+    });
+
+    // If title or company is missing, try alternative extraction
+    if (!title || !company) {
+      console.log(
+        "AppliStash: Missing title or company, trying alternative extraction"
+      );
+
+      // Try to get job title from document title
+      const pageTitle = document.title;
+      const extractedTitle = pageTitle
+        .split(" | ")[0]
+        .trim();
+
+      // Try to get company from meta tags or other elements
+      const metaCompany = document
+        .querySelector('meta[property="og:site_name"]')
+        ?.getAttribute("content");
+
+      if (extractedTitle) {
+        console.log(
+          "AppliStash: Using extracted title from page title:",
+          extractedTitle
+        );
+        return {
+          title: extractedTitle,
+          company: company || metaCompany || "LinkedIn",
+          location: location || "Unknown location",
+          description:
+            description || "No description available",
+          url,
+          source: "LinkedIn",
+        };
+      }
+
+      return null;
+    }
+
+    return {
+      title,
+      company,
+      location,
+      description,
+      url,
+      source: "LinkedIn",
+    };
+  } catch (error) {
+    console.error(
+      "AppliStash: Error extracting LinkedIn job data",
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Function to extract Indeed job data with specific handling
+ */
+export function extractIndeedJobData(): JobData | null {
+  try {
+    // Indeed specific selectors
+    const titleElement = document.querySelector(
+      ".jobsearch-JobInfoHeader-title"
+    );
+    const companyElement = document.querySelector(
+      ".jobsearch-CompanyInfoContainer .jobsearch-InlineCompanyRating div:first-child"
+    );
+    const locationElement = document.querySelector(
+      ".jobsearch-JobInfoHeader-subtitle .jobsearch-JobInfoHeader-locationText"
+    );
+    const descriptionElement = document.querySelector(
+      "#jobDescriptionText"
+    );
+
+    const title = titleElement
+      ? titleElement.textContent?.trim() || ""
+      : "";
+    const company = companyElement
+      ? companyElement.textContent?.trim() || ""
+      : "";
+    const location = locationElement
+      ? locationElement.textContent?.trim() || ""
+      : "";
+    const description = descriptionElement
+      ? descriptionElement.textContent?.trim() || ""
+      : "";
+    const url = window.location.href;
+
+    if (!title || !company) {
+      return null;
+    }
+
+    return {
+      title,
+      company,
+      location,
+      description,
+      url,
+      source: "Indeed",
+    };
+  } catch (error) {
+    console.error(
+      "AppliStash: Error extracting Indeed job data",
+      error
+    );
+    return null;
+  }
+}

--- a/apps/extension/src/content/ui.ts
+++ b/apps/extension/src/content/ui.ts
@@ -1,0 +1,169 @@
+import type { JobData, User } from "./overlay";
+
+/**
+ * Creates the UI for the overlay that will be injected into job pages
+ */
+export function createOverlayUI(
+  jobData: JobData,
+  user: User,
+  onSave: (data: JobData) => void
+): HTMLElement {
+  // Create the main overlay container
+  const overlay = document.createElement("div");
+  overlay.className = "appli-stash-overlay";
+  overlay.style.position = "fixed";
+  overlay.style.bottom = "20px";
+  overlay.style.right = "20px";
+  overlay.style.backgroundColor = "white";
+  overlay.style.borderRadius = "8px";
+  overlay.style.boxShadow =
+    "0 0 0 4px #6a3cf7, 0 4px 20px rgba(0,0,0,0.4)";
+  overlay.style.padding = "16px";
+  overlay.style.zIndex = "2147483647"; // Maximum z-index value
+  overlay.style.width = "320px";
+  overlay.style.maxWidth = "90vw";
+  overlay.style.fontFamily = "Arial, sans-serif";
+  overlay.style.fontSize = "14px";
+  overlay.style.transition = "all 0.3s ease";
+  overlay.style.border = "3px solid #6a3cf7";
+  overlay.style.animation =
+    "appliStashPulse 2s infinite alternate";
+
+  // Add animation to make it more visible
+  const style = document.createElement("style");
+  style.textContent = `
+    @keyframes appliStashPulse {
+      0% { box-shadow: 0 0 0 4px #6a3cf7, 0 4px 20px rgba(0,0,0,0.4); }
+      100% { box-shadow: 0 0 0 8px #6a3cf7, 0 4px 25px rgba(106, 60, 247, 0.6); }
+    }
+  `;
+  document.head.appendChild(style);
+
+  // Create the header
+  const header = document.createElement("div");
+  header.style.display = "flex";
+  header.style.alignItems = "center";
+  header.style.marginBottom = "12px";
+
+  // Logo
+  const logo = document.createElement("div");
+  logo.textContent = "AppliStash";
+  logo.style.color = "#6a3cf7";
+  logo.style.fontWeight = "bold";
+  logo.style.fontSize = "16px";
+
+  // Close button
+  const closeButton = document.createElement("button");
+  closeButton.innerHTML = "&times;";
+  closeButton.style.marginLeft = "auto";
+  closeButton.style.background = "none";
+  closeButton.style.border = "none";
+  closeButton.style.fontSize = "20px";
+  closeButton.style.cursor = "pointer";
+  closeButton.style.padding = "0 6px";
+  closeButton.onclick = () => {
+    overlay.remove();
+  };
+
+  header.appendChild(logo);
+  header.appendChild(closeButton);
+
+  // Create the content
+  const content = document.createElement("div");
+
+  // Job title
+  const title = document.createElement("div");
+  title.textContent = jobData.title;
+  title.style.fontWeight = "bold";
+  title.style.marginBottom = "8px";
+
+  // Company
+  const company = document.createElement("div");
+  company.textContent = jobData.company;
+  company.style.marginBottom = "4px";
+
+  // Location
+  const location = document.createElement("div");
+  location.textContent = jobData.location;
+  location.style.marginBottom = "12px";
+  location.style.color = "#666";
+
+  // Add to AppliStash button
+  const saveButton = document.createElement("button");
+  saveButton.textContent = "Save to AppliStash";
+  saveButton.style.backgroundColor = "#6a3cf7";
+  saveButton.style.color = "white";
+  saveButton.style.border = "none";
+  saveButton.style.padding = "10px 16px";
+  saveButton.style.borderRadius = "6px";
+  saveButton.style.width = "100%";
+  saveButton.style.cursor = "pointer";
+  saveButton.style.fontWeight = "bold";
+  saveButton.style.marginTop = "10px";
+  saveButton.onclick = () => {
+    saveButton.disabled = true;
+    saveButton.textContent = "Saving...";
+
+    // Call the save function
+    onSave(jobData);
+
+    // After a delay, update the button
+    setTimeout(() => {
+      saveButton.textContent = "Saved!";
+      saveButton.style.backgroundColor = "#4CAF50";
+
+      // Reset after 3 seconds
+      setTimeout(() => {
+        saveButton.disabled = false;
+        saveButton.textContent = "Save to AppliStash";
+        saveButton.style.backgroundColor = "#6a3cf7";
+      }, 3000);
+    }, 1000);
+  };
+
+  // Logged in as
+  const userInfo = document.createElement("div");
+  userInfo.textContent = `Logged in as ${user.name}`;
+  userInfo.style.fontSize = "12px";
+  userInfo.style.color = "#666";
+  userInfo.style.textAlign = "center";
+  userInfo.style.marginTop = "10px";
+
+  // Assemble the content
+  content.appendChild(title);
+  content.appendChild(company);
+  content.appendChild(location);
+  content.appendChild(saveButton);
+  content.appendChild(userInfo);
+
+  // Assemble the overlay
+  overlay.appendChild(header);
+  overlay.appendChild(content);
+
+  // Add a minimize/expand toggle
+  let isMinimized = false;
+
+  const toggleButton = document.createElement("button");
+  toggleButton.innerHTML = "&#8593;"; // Up arrow
+  toggleButton.style.position = "absolute";
+  toggleButton.style.top = "16px";
+  toggleButton.style.right = "40px";
+  toggleButton.style.background = "none";
+  toggleButton.style.border = "none";
+  toggleButton.style.cursor = "pointer";
+  toggleButton.onclick = () => {
+    if (isMinimized) {
+      content.style.display = "block";
+      toggleButton.innerHTML = "&#8593;"; // Up arrow
+      isMinimized = false;
+    } else {
+      content.style.display = "none";
+      toggleButton.innerHTML = "&#8595;"; // Down arrow
+      isMinimized = true;
+    }
+  };
+
+  header.appendChild(toggleButton);
+
+  return overlay;
+}

--- a/apps/extension/src/manifest.json
+++ b/apps/extension/src/manifest.json
@@ -20,5 +20,17 @@
     "16": "assets/icon16.png",
     "48": "assets/icon48.png",
     "128": "assets/icon128.png"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.linkedin.com/*jobs*",
+        "*://*.indeed.com/viewjob*",
+        "*://*.indeed.com/job*",
+        "*://*.glassdoor.com/job-details*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
   entry: {
     popup: "./src/popup/index.tsx",
     background: "./src/background/index.ts",
+    content: "./src/content/index.ts",
   },
   output: {
     path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
Introduces a content script for the browser extension that detects supported job sites (LinkedIn, Indeed, Glassdoor), extracts job data, and injects an overlay UI for saving job applications. Updates manifest and webpack config to register the content script, and implements site detection, data extraction, overlay UI, and user handling logic.