### PR TITLE
Add drag-and-drop to application board with column status

### DIFF
--- a/apps/web/app/dashboard/page.client.tsx
+++ b/apps/web/app/dashboard/page.client.tsx
@@ -100,7 +100,10 @@ export default function DashboardPage() {
             {appError}
           </div>
         ) : (
-          <Board applications={applications} onItemClick={setEditApp} />
+          <Board 
+            applications={applications} 
+            onItemClick={setEditApp} 
+          />
         )}
         
         <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)} title="Add Application">

--- a/apps/web/components/board/ApplicationItem.tsx
+++ b/apps/web/components/board/ApplicationItem.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import type { Application } from "@shared/types";
+import { Draggable } from "@hello-pangea/dnd";
 
 interface ApplicationItemProps {
   application: Application;
   onClick?: ((application: Application) => void) | undefined;
+  index: number;
 }
 
-export function ApplicationItem({ application, onClick }: ApplicationItemProps) {
+export function ApplicationItem({ application, onClick, index }: ApplicationItemProps) {
   // Function to get company logo or display first letter in a circle
   const getCompanyDisplay = () => {
     // For this example, we'll use the first letter of company name
@@ -36,38 +38,50 @@ export function ApplicationItem({ application, onClick }: ApplicationItemProps) 
   };
   
   return (
-    <div
-      className="bg-white rounded-lg p-3 border border-gray-200 cursor-pointer transition-all duration-200"
-      style={{ 
-        boxShadow: '0px 2px 6px rgba(0, 0, 0, 0.05)',
-        borderLeftWidth: '4px',
-        borderLeftColor: getBorderColor()
-      }}
-      onClick={() => onClick && onClick(application)}
-      tabIndex={0}
-      role="button"
-      aria-label={`Edit application for ${application.company_name}`}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.boxShadow = '0px 4px 12px rgba(0, 0, 0, 0.1)';
-        e.currentTarget.style.transform = 'translateY(-1px)';
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.boxShadow = '0px 2px 6px rgba(0, 0, 0, 0.05)';
-        e.currentTarget.style.transform = 'translateY(0px)';
-      }}
+    <Draggable 
+      draggableId={application.id ? String(application.id) : `temp-${application.company_name}`} 
+      index={index}
     >
-      <div className="flex flex-col">
-        <div className="flex items-center gap-2 mb-1">
-          {getCompanyDisplay()}
-          <div className="flex-1 ml-1">
-            <div className="text-secondary text-lg font-semibold">{application.position}</div>
-            <div className="text-gray-500 text-base">{application.company_name}</div>
-          </div>
-          <div className="text-secondary text-sm whitespace-nowrap">
-            1mo
+      {(provided, snapshot) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          className={`bg-white rounded-lg p-3 border border-gray-200 cursor-pointer transition-all duration-200 ${
+            snapshot.isDragging ? 'shadow-lg ring-2 ring-primary ring-opacity-50' : ''
+          }`}
+          style={{ 
+            ...provided.draggableProps.style,
+            boxShadow: snapshot.isDragging 
+              ? '0px 8px 16px rgba(0, 0, 0, 0.1)' 
+              : '0px 2px 6px rgba(0, 0, 0, 0.05)',
+            borderLeftWidth: '4px',
+            borderLeftColor: getBorderColor()
+          }}
+          onClick={(e) => {
+            if (!snapshot.isDragging && onClick) {
+              e.stopPropagation();
+              onClick(application);
+            }
+          }}
+          tabIndex={0}
+          role="button"
+          aria-label={`Edit application for ${application.company_name}`}
+        >
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2 mb-1">
+              {getCompanyDisplay()}
+              <div className="flex-1 ml-1">
+                <div className="text-secondary text-lg font-semibold">{application.position}</div>
+                <div className="text-gray-500 text-base">{application.company_name}</div>
+              </div>
+              <div className="text-secondary text-sm whitespace-nowrap">
+                1mo
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+      )}
+    </Draggable>
   );
 }

--- a/apps/web/components/board/Board.tsx
+++ b/apps/web/components/board/Board.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { ApplicationStatus, Application } from "@shared/types";
 import { Column } from "./Column";
+import { DragDropContext, DropResult } from "@hello-pangea/dnd";
 
 interface BoardProps {
   applications: Application[];
@@ -8,23 +9,105 @@ interface BoardProps {
 }
 
 export function Board({ applications, onItemClick }: BoardProps) {
+  // State to keep track of applications locally
+  const [localApplications, setLocalApplications] = useState<Application[]>(applications);
+  
+  // Update local applications when the prop changes
+  useEffect(() => {
+    setLocalApplications(applications);
+  }, [applications]);
+
   // Group applications by status
   const columns = Object.values(ApplicationStatus).map((status) => ({
     status,
-    items: applications.filter((app) => app.status === status),
+    items: localApplications.filter((app) => app.status === status),
   }));
 
+  // Update application status via API
+  const updateApplicationStatus = async (appId: string, newStatus: ApplicationStatus) => {
+    if (!appId) return;
+    
+    try {
+      // Find the full application to ensure we have all required fields
+      const application = localApplications.find(app => String(app.id) === appId);
+      if (!application) return;
+      
+      const response = await fetch(`/api/application`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          id: appId,
+          status: newStatus,
+          // Include other required fields to avoid overwriting them with null
+          company_name: application.company_name,
+          position: application.position,
+          url: application.url,
+          priority_level: application.priority_level,
+          notes: application.notes
+        })
+      });
+      
+      if (!response.ok) {
+        const errorData = await response.json();
+        console.error('Failed to update application status:', errorData);
+      }
+    } catch (error) {
+      console.error('Error updating application status:', error);
+    }
+  };
+
+  // Handle drag end event
+  const handleDragEnd = (result: DropResult) => {
+    const { source, destination, draggableId } = result;
+    
+    // If dropped outside a droppable area or in the same position
+    if (!destination || 
+        (source.droppableId === destination.droppableId && 
+         source.index === destination.index)) {
+      return;
+    }
+    
+    // Find the application that was dragged
+    // draggableId might be a string representation of a number or a temp id
+    const application = localApplications.find(app => 
+      String(app.id) === draggableId || 
+      (draggableId.startsWith('temp-') && `temp-${app.company_name}` === draggableId)
+    );
+    
+    if (!application) return;
+    
+    // Create a new status based on the destination column
+    const newStatus = destination.droppableId as ApplicationStatus;
+    
+    // Update local state immediately for better UX
+    const updatedApplications = localApplications.map(app => 
+      app.id === application.id 
+        ? { ...app, status: newStatus } 
+        : app
+    );
+    
+    setLocalApplications(updatedApplications);
+    
+    // Send update to the server
+    updateApplicationStatus(String(application.id), newStatus);
+  };
+
   return (
-    <div className="flex flex-col md:flex-row gap-8 w-full md:overflow-x-auto pb-6">
-      {columns.map((col) => (
-        <Column
-          key={col.status}
-          status={col.status}
-          items={col.items}
-          itemCount={col.items.length}
-          {...(onItemClick ? { onItemClick } : {})}
-        />
-      ))}
-    </div>
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <div className="flex flex-col md:flex-row gap-8 w-full md:overflow-x-auto pb-6">
+        {columns.map((col) => (
+          <Column
+            key={col.status}
+            status={col.status}
+            items={col.items}
+            itemCount={col.items.length}
+            {...(onItemClick ? { onItemClick } : {})}
+          />
+        ))}
+      </div>
+    </DragDropContext>
   );
 }

--- a/apps/web/components/board/Column.tsx
+++ b/apps/web/components/board/Column.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Application, ApplicationStatus } from "@shared/types";
 import { ApplicationItem } from "./ApplicationItem";
+import { Droppable } from "@hello-pangea/dnd";
 
 interface ColumnProps {
   status: ApplicationStatus;
@@ -37,32 +38,51 @@ export function Column({ status, items, itemCount = 0, onItemClick }: ColumnProp
         </div>
         <span className="text-secondary text-sm">{itemCount} JOBS</span>
       </div>
-      <div className="space-y-5 mt-6">
-        {/* Add button for adding new applications */}
-        <div className="flex justify-center">
-          <button 
-            className="w-full border border-secondary rounded-lg py-3 flex justify-center items-center text-secondary hover:bg-gray-50 transition-colors"
-            onClick={(e) => {
-              e.stopPropagation();
-              // We'll trigger the same add application modal that's used elsewhere
-              const addButton = document.querySelector('button[data-add-application]');
-              if (addButton instanceof HTMLElement) {
-                addButton.click();
-              }
-            }}
-          >
-            <span className="text-2xl">+</span>
-          </button>
-        </div>
-        
-        {items.length === 0 ? (
-          <div className="text-secondary text-sm text-center mt-4">No applications</div>
-        ) : (
-          items.map((app) => (
-            <ApplicationItem key={app.id || app.company_name} application={app} onClick={onItemClick} />
-          ))
-        )}
+      
+      {/* Add button for adding new applications */}
+      <div className="flex justify-center mb-5">
+        <button 
+          className="w-full border border-secondary rounded-lg py-3 flex justify-center items-center text-secondary hover:bg-gray-50 transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            // Store the status in localStorage to be picked up by the form
+            localStorage.setItem('newApplicationStatus', status);
+            // Trigger the same add application modal that's used elsewhere
+            const addButton = document.querySelector('button[data-add-application]');
+            if (addButton instanceof HTMLElement) {
+              addButton.click();
+            }
+          }}
+        >
+          <span className="text-2xl">+</span>
+        </button>
       </div>
+      
+      <Droppable droppableId={status}>
+        {(provided, snapshot) => (
+          <div 
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+            className={`space-y-5 min-h-[100px] transition-colors ${
+              snapshot.isDraggingOver ? 'bg-gray-50 rounded-lg p-2' : ''
+            }`}
+          >
+            {items.length === 0 ? (
+              <div className="text-secondary text-sm text-center mt-4">No applications</div>
+            ) : (
+              items.map((app, index) => (
+                <ApplicationItem 
+                  key={app.id || app.company_name} 
+                  application={app} 
+                  onClick={onItemClick}
+                  index={index}
+                />
+              ))
+            )}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
     </div>
   );
 }

--- a/apps/web/components/forms/ApplicationForm.tsx
+++ b/apps/web/components/forms/ApplicationForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { Select } from "@shared/components/ui/Select";
@@ -31,6 +31,20 @@ export function ApplicationForm({ initial, onSuccess }: ApplicationFormProps) {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [showSuccess, setShowSuccess] = useState(false);
+
+  // Check for column-specific status on mount
+  useEffect(() => {
+    const columnStatus = localStorage.getItem('newApplicationStatus');
+    if (columnStatus && !initial) {
+      console.log('Setting status from localStorage:', columnStatus);
+      setForm(prev => ({
+        ...prev,
+        status: columnStatus as ApplicationStatus
+      }));
+      // Clear localStorage after using it
+      localStorage.removeItem('newApplicationStatus');
+    }
+  }, [initial]);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) {
     const { name, value } = e.target;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "@supabase/supabase-js": "^2.57.0",
     "@types/jsonwebtoken": "^9.0.10",
     "jsonwebtoken": "^9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hello-pangea/dnd':
+        specifier: ^18.0.1
+        version: 18.0.1(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@supabase/supabase-js':
         specifier: ^2.57.0
         version: 2.57.4
@@ -119,6 +122,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
@@ -169,6 +176,12 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hello-pangea/dnd@18.0.1':
+    resolution: {integrity: sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -669,6 +682,9 @@ packages:
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
 
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1119,6 +1135,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-box-model@1.2.1:
+    resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
 
   css-loader@6.11.0:
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
@@ -2206,6 +2225,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  raf-schd@4.0.3:
+    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -2222,6 +2244,18 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2237,6 +2271,9 @@ packages:
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2501,6 +2538,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2574,6 +2614,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2678,6 +2723,8 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@babel/runtime@7.28.4': {}
+
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@emnapi/core@1.5.0':
@@ -2739,6 +2786,18 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@hello-pangea/dnd@18.0.1(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      css-box-model: 1.2.1
+      raf-schd: 4.0.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-redux: 9.2.0(@types/react@19.1.12)(react@19.1.0)(redux@5.0.1)
+      redux: 5.0.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@humanfs/core@0.19.1': {}
 
@@ -3166,6 +3225,8 @@ snapshots:
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.1.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -3663,6 +3724,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-box-model@1.2.1:
+    dependencies:
+      tiny-invariant: 1.3.3
 
   css-loader@6.11.0(webpack@5.101.3):
     dependencies:
@@ -4877,6 +4942,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  raf-schd@4.0.3: {}
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -4894,6 +4961,15 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@19.1.12)(react@19.1.0)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      redux: 5.0.1
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4906,6 +4982,8 @@ snapshots:
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.10
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5239,6 +5317,8 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5354,6 +5434,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Integrates @hello-pangea/dnd to enable drag-and-drop for applications between columns on the board. Updates application status both locally and via API on drop. Adds logic to pre-select column status when adding a new application. Updates ApplicationItem, Board, Column, and ApplicationForm components to support these features. Adds @hello-pangea/dnd as a dependency.