### PR TITLE
Refactor layout to use MainLayout component

### DIFF
--- a/apps/web/app/contacts/page.tsx
+++ b/apps/web/app/contacts/page.tsx
@@ -1,12 +1,10 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useUser } from "../../components/context/UserContext";
-import Header from "../../components/layout/Header";
-import Footer from "../../components/layout/Footer";
 import { Modal } from "@shared/components/ui/Modal";
 import { ContactForm } from "../../components/forms/ContactForm";
 import { ContactItem, Contact } from "../../components/contacts/ContactItem";
-import { Sidebar } from "../../components/layout/Sidebar";
+import { MainLayout } from "../../components/layout/MainLayout";
 
 export default function ContactsPage() {
   const { user, loading } = useUser();
@@ -15,13 +13,6 @@ export default function ContactsPage() {
   const [contactError, setContactError] = useState("");
   const [modalOpen, setModalOpen] = useState(false);
   const [editContact, setEditContact] = useState<Contact | null>(null);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-
-  useEffect(() => {
-    if (!loading && !user) {
-      window.location.href = "/login";
-    }
-  }, [user, loading]);
 
   useEffect(() => {
     if (!user) return;
@@ -82,29 +73,9 @@ export default function ContactsPage() {
     return <div className="flex items-center justify-center h-screen">Loading...</div>;
   }
 
-  if (!user) {
-    return null;
-  }
-
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* Sidebar */}
-      <Sidebar 
-        isCollapsed={sidebarCollapsed} 
-        onToggle={() => setSidebarCollapsed(!sidebarCollapsed)} 
-      />
-      
-      {/* Main Content */}
-      <div className={`flex flex-col flex-1 transition-all duration-300 ${
-        sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-64'
-      }`}>
-        {/* Header */}
-        <div className="flex-shrink-0">
-          <Header />
-        </div>
-        
-        {/* Main Content Area */}
-        <main className="flex-grow p-4 overflow-auto">
+    <MainLayout>
+      <div className="p-4">
         <div className="max-w-7xl mx-auto">
           {/* Header Section */}
           <div className="flex justify-between items-center mb-6 flex-wrap">
@@ -280,13 +251,7 @@ export default function ContactsPage() {
             </div>
           )}
         </Modal>
-        </main>
-        
-        {/* Footer */}
-        <div className="flex-shrink-0 mt-auto">
-          <Footer />
-        </div>
       </div>
-    </div>
+    </MainLayout>
   );
 }

--- a/apps/web/app/dashboard/page.client.tsx
+++ b/apps/web/app/dashboard/page.client.tsx
@@ -1,14 +1,12 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useUser } from "../../components/context/UserContext";
-import Header from "../../components/layout/Header";
-import Footer from "../../components/layout/Footer";
 import { Modal } from "@shared/components/ui/Modal";
 import { ApplicationForm } from "../../components/forms/ApplicationForm";
 import { ContactForm } from "../../components/forms/ContactForm";
 import { InterviewForm } from "../../components/forms/InterviewForm";
 import { Board } from "../../components/board/Board";
-import { Sidebar } from "../../components/layout/Sidebar";
+import { MainLayout } from "../../components/layout/MainLayout";
 import type { Application } from "@shared/types";
 
 export default function DashboardPage() {
@@ -16,17 +14,10 @@ export default function DashboardPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [interviewModalOpen, setInterviewModalOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [editApp, setEditApp] = useState<Application | null>(null);
   const [applications, setApplications] = useState<Application[]>([]);
   const [appLoading, setAppLoading] = useState(true);
   const [appError, setAppError] = useState("");
-
-  useEffect(() => {
-    if (!loading && !user) {
-      window.location.href = "/login";
-    }
-  }, [user, loading]);
 
   useEffect(() => {
     if (!user) return;
@@ -79,96 +70,79 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      <Sidebar 
-        isCollapsed={sidebarCollapsed} 
-        onToggle={() => setSidebarCollapsed(!sidebarCollapsed)} 
-      />
-      
-      <div className={`flex flex-col flex-1 transition-all duration-300 ${
-        sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-64'
-      }`}>
-        <div className="flex-shrink-0">
-          <Header />
+    <MainLayout>
+      <div className="p-4 bg-white">
+        <div className="flex justify-between items-center mb-6 flex-wrap">
+          <h1 className="text-2xl font-bold text-[#581C87] mb-2 md:mb-0">Applications</h1>
+          <div className="flex gap-2 flex-wrap">
+            <button
+              className="px-4 py-2 bg-primary text-accent rounded shadow hover:bg-secondary hover:text-accent border border-primary"
+              onClick={() => setModalOpen(true)}
+              data-add-application
+            >
+              Add Application
+            </button>
+            <button
+              className="px-4 py-2 bg-[#3B82F6] text-white rounded shadow hover:bg-[#2563EB] border border-[#3B82F6]"
+              onClick={() => setInterviewModalOpen(true)}
+            >
+              Add Interview
+            </button>
+          </div>
         </div>
         
-        <main className="flex-grow p-4 bg-white overflow-auto">
-          <div className="flex justify-between items-center mb-6 flex-wrap">
-            <h1 className="text-2xl font-bold text-[#581C87] mb-2 md:mb-0">Applications</h1>
-            <div className="flex gap-2 flex-wrap">
-              <button
-                className="px-4 py-2 bg-primary text-accent rounded shadow hover:bg-secondary hover:text-accent border border-primary"
-                onClick={() => setModalOpen(true)}
-                data-add-application
-              >
-                Add Application
-              </button>
-              <button
-                className="px-4 py-2 bg-[#3B82F6] text-white rounded shadow hover:bg-[#2563EB] border border-[#3B82F6]"
-                onClick={() => setInterviewModalOpen(true)}
-              >
-                Add Interview
-              </button>
-            </div>
+        {appLoading ? (
+          <div className="flex justify-center items-center h-64">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-purple-500"></div>
           </div>
-          
-          {appLoading ? (
-            <div className="flex justify-center items-center h-64">
-              <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-purple-500"></div>
-            </div>
-          ) : appError ? (
-            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-              {appError}
-            </div>
-          ) : (
-            <Board 
-              applications={applications} 
-              onItemClick={setEditApp} 
-            />
-          )}
-          
-          <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)} title="Add Application">
-            <ApplicationForm
+        ) : appError ? (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+            {appError}
+          </div>
+        ) : (
+          <Board 
+            applications={applications} 
+            onItemClick={setEditApp} 
+          />
+        )}
+        
+        <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)} title="Add Application">
+          <ApplicationForm
+            onSuccess={() => {
+              setModalOpen(false);
+              refreshApplications();
+            }}
+          />
+        </Modal>
+        
+        <Modal isOpen={contactModalOpen} onClose={() => setContactModalOpen(false)} title="Add Contact">
+          <ContactForm
+            onSuccess={() => {
+              setContactModalOpen(false);
+            }}
+          />
+        </Modal>
+        
+        <Modal isOpen={interviewModalOpen} onClose={() => setInterviewModalOpen(false)} title="Add Interview">
+          <InterviewForm
+            onSuccess={() => {
+              setInterviewModalOpen(false);
+            }}
+          />
+        </Modal>
+        
+        <Modal isOpen={!!editApp} onClose={() => setEditApp(null)} title="Edit Application">
+          {editApp && (
+            <ApplicationForm 
+              initial={editApp} 
               onSuccess={() => {
-                setModalOpen(false);
+                setEditApp(null);
                 refreshApplications();
               }}
             />
-          </Modal>
-          
-          <Modal isOpen={contactModalOpen} onClose={() => setContactModalOpen(false)} title="Add Contact">
-            <ContactForm
-              onSuccess={() => {
-                setContactModalOpen(false);
-              }}
-            />
-          </Modal>
-          
-          <Modal isOpen={interviewModalOpen} onClose={() => setInterviewModalOpen(false)} title="Add Interview">
-            <InterviewForm
-              onSuccess={() => {
-                setInterviewModalOpen(false);
-              }}
-            />
-          </Modal>
-          
-          <Modal isOpen={!!editApp} onClose={() => setEditApp(null)} title="Edit Application">
-            {editApp && (
-              <ApplicationForm 
-                initial={editApp} 
-                onSuccess={() => {
-                  setEditApp(null);
-                  refreshApplications();
-                }}
-              />
-            )}
-          </Modal>
-        </main>
-        
-        <div className="flex-shrink-0 mt-auto">
-          <Footer />
-        </div>
+          )}
+        </Modal>
       </div>
-    </div>
+    </MainLayout>
   );
 }

--- a/apps/web/app/interviews/page.tsx
+++ b/apps/web/app/interviews/page.tsx
@@ -1,118 +1,76 @@
 "use client";
-import React, { useState, useEffect } from "react";
-import { useUser } from "../../components/context/UserContext";
-import Header from "../../components/layout/Header";
-import Footer from "../../components/layout/Footer";
-import { Sidebar } from "../../components/layout/Sidebar";
+import React from "react";
+import { MainLayout } from "../../components/layout/MainLayout";
 
 export default function InterviewsPage() {
-  const { user, loading } = useUser();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-
-  useEffect(() => {
-    if (!loading && !user) {
-      window.location.href = "/login";
-    }
-  }, [user, loading]);
-
-  if (loading) {
-    return <div className="flex items-center justify-center h-screen">Loading...</div>;
-  }
-
-  if (!user) {
-    return null;
-  }
-
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* Sidebar */}
-      <Sidebar 
-        isCollapsed={sidebarCollapsed} 
-        onToggle={() => setSidebarCollapsed(!sidebarCollapsed)} 
-      />
-      
-      {/* Main Content */}
-      <div className={`flex flex-col flex-1 transition-all duration-300 ${
-        sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-64'
-      }`}>
-        {/* Header */}
-        <div className="flex-shrink-0">
-          <Header />
-        </div>
-        
-        {/* Main Content Area */}
-        <main className="flex-grow p-6 overflow-auto">
-          <div className="max-w-7xl mx-auto">
-            {/* Header Section */}
-            <div className="mb-8">
-              <h1 className="text-3xl font-bold text-gray-900 mb-2">Interviews</h1>
-              <p className="text-gray-600">
-                Manage and track your job interviews
-              </p>
-            </div>
+    <MainLayout>
+      <div className="p-6">
+        <div className="max-w-7xl mx-auto">
+          {/* Header Section */}
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">Interviews</h1>
+            <p className="text-gray-600">
+              Manage and track your job interviews
+            </p>
+          </div>
 
-            {/* Coming Soon Section */}
-            <div className="bg-white rounded-lg shadow-sm p-8 text-center">
-              <div className="w-16 h-16 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
-                <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
+          {/* Coming Soon Section */}
+          <div className="bg-white rounded-lg shadow-sm p-8 text-center">
+            <div className="w-16 h-16 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
+              <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              Interview Management Coming Soon
+            </h2>
+            
+            <p className="text-gray-600 mb-6 max-w-2xl mx-auto">
+              We&apos;re building an amazing interview tracking system that will help you:
+            </p>
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+              <div className="p-4 bg-gray-50 rounded-lg">
+                <div className="w-8 h-8 mx-auto mb-2 text-blue-600">
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                </div>
+                <h3 className="font-semibold text-gray-900 mb-1">Schedule Interviews</h3>
+                <p className="text-sm text-gray-600">Keep track of all your upcoming interviews</p>
               </div>
               
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
-                Interview Management Coming Soon
-              </h2>
+              <div className="p-4 bg-gray-50 rounded-lg">
+                <div className="w-8 h-8 mx-auto mb-2 text-green-600">
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                </div>
+                <h3 className="font-semibold text-gray-900 mb-1">Track Progress</h3>
+                <p className="text-sm text-gray-600">Monitor interview status and outcomes</p>
+              </div>
               
-              <p className="text-gray-600 mb-6 max-w-2xl mx-auto">
-                We&apos;re building an amazing interview tracking system that will help you:
+              <div className="p-4 bg-gray-50 rounded-lg">
+                <div className="w-8 h-8 mx-auto mb-2 text-purple-600">
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
+                  </svg>
+                </div>
+                <h3 className="font-semibold text-gray-900 mb-1">Prepare Better</h3>
+                <p className="text-sm text-gray-600">Store notes and preparation materials</p>
+              </div>
+            </div>
+            
+            <div className="p-4 bg-blue-50 rounded-lg">
+              <p className="text-sm text-blue-800">
+                <strong>In the meantime:</strong> You can still add interviews from the Dashboard by clicking &quot;Add Interview&quot; and linking them to your applications.
               </p>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-                <div className="p-4 bg-gray-50 rounded-lg">
-                  <div className="w-8 h-8 mx-auto mb-2 text-blue-600">
-                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                  </div>
-                  <h3 className="font-semibold text-gray-900 mb-1">Schedule Interviews</h3>
-                  <p className="text-sm text-gray-600">Keep track of all your upcoming interviews</p>
-                </div>
-                
-                <div className="p-4 bg-gray-50 rounded-lg">
-                  <div className="w-8 h-8 mx-auto mb-2 text-green-600">
-                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                    </svg>
-                  </div>
-                  <h3 className="font-semibold text-gray-900 mb-1">Track Progress</h3>
-                  <p className="text-sm text-gray-600">Monitor interview status and outcomes</p>
-                </div>
-                
-                <div className="p-4 bg-gray-50 rounded-lg">
-                  <div className="w-8 h-8 mx-auto mb-2 text-purple-600">
-                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
-                    </svg>
-                  </div>
-                  <h3 className="font-semibold text-gray-900 mb-1">Prepare Better</h3>
-                  <p className="text-sm text-gray-600">Store notes and preparation materials</p>
-                </div>
-              </div>
-              
-              <div className="p-4 bg-blue-50 rounded-lg">
-                <p className="text-sm text-blue-800">
-                  <strong>In the meantime:</strong> You can still add interviews from the Dashboard by clicking &quot;Add Interview&quot; and linking them to your applications.
-                </p>
-              </div>
             </div>
           </div>
-        </main>
-        
-        {/* Footer */}
-        <div className="flex-shrink-0 mt-auto">
-          <Footer />
         </div>
       </div>
-    </div>
+    </MainLayout>
   );
 }

--- a/apps/web/components/layout/Header.tsx
+++ b/apps/web/components/layout/Header.tsx
@@ -38,24 +38,7 @@ export default function Header() {
         </Link>
       </div>
       
-      {/* Navigation Links */}
-      {!loading && user && (
-        <nav className="hidden md:flex items-center gap-6">
-          {navigationLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={`text-sm font-medium transition-colors hover:text-secondary ${
-                pathname === link.href
-                  ? "text-secondary border-b-2 border-secondary pb-1"
-                  : "text-accent"
-              }`}
-            >
-              {link.label}
-            </Link>
-          ))}
-        </nav>
-      )}
+      
 
       <nav className="flex items-center gap-2 md:gap-4 text-accent">
         {!loading && user && (

--- a/apps/web/components/layout/MainLayout.tsx
+++ b/apps/web/components/layout/MainLayout.tsx
@@ -1,0 +1,53 @@
+"use client";
+import React, { useEffect, ReactNode } from "react";
+import { useUser } from "../context/UserContext";
+import Header from "./Header";
+import Footer from "./Footer";
+import { Sidebar } from "./Sidebar";
+
+interface MainLayoutProps {
+  children: ReactNode;
+}
+
+export function MainLayout({ children }: MainLayoutProps) {
+  const { user, loading } = useUser();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      window.location.href = "/login";
+    }
+  }, [user, loading]);
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-screen">Loading...</div>;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col h-screen bg-gray-50">
+      {/* Header - 10% */}
+      <div className="flex-shrink-0 h-[5vh] w-full">
+        <Header />
+      </div>
+      
+      {/* Main Content Area with Sidebar - 85% */}
+      <div className="flex flex-1 h-[92.5vh]">
+        {/* Sidebar */}
+        <Sidebar />
+        
+        {/* Page Content */}
+        <main className="flex-1 overflow-auto">
+          {children}
+        </main>
+      </div>
+      
+      {/* Footer - 5% */}
+      <div className="flex-shrink-0 h-[2.5vh] w-full text-sm">
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/layout/Sidebar.tsx
+++ b/apps/web/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -21,27 +22,14 @@ const InterviewIcon = ({ className = "w-6 h-6" }: { className?: string }) => (
   </svg>
 );
 
-const MenuIcon = ({ className = "w-6 h-6" }: { className?: string }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <line x1="3" y1="6" x2="21" y2="6"></line>
-    <line x1="3" y1="12" x2="21" y2="12"></line>
-    <line x1="3" y1="18" x2="21" y2="18"></line>
-  </svg>
-);
-
-const ChevronLeftIcon = ({ className = "w-6 h-6" }: { className?: string }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <polyline points="15,18 9,12 15,6"></polyline>
-  </svg>
-);
-
-interface SidebarProps {
-  isCollapsed: boolean;
-  onToggle: () => void;
-}
-
-export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
+export function Sidebar() {
   const pathname = usePathname();
+  const [isHovering, setIsHovering] = useState(false);
+
+  // Reset hover state when navigating to a new page
+  useEffect(() => {
+    setIsHovering(false);
+  }, [pathname]);
 
   const navigationItems = [
     {
@@ -70,39 +58,17 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
 
   return (
     <>
-      {/* Mobile Overlay */}
-      {!isCollapsed && (
-        <div 
-          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
-          onClick={onToggle}
-        />
-      )}
-      
       {/* Sidebar */}
-      <div className={`
-        fixed left-0 top-0 h-full bg-white border-r border-gray-200 z-50 transition-all duration-300 ease-in-out
-        ${isCollapsed ? '-translate-x-full lg:translate-x-0 lg:w-16' : 'translate-x-0 w-64'}
-      `}>
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
-          {!isCollapsed && (
-            <h2 className="text-lg font-semibold text-gray-800">Navigation</h2>
-          )}
-          <button
-            onClick={onToggle}
-            className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-          >
-            {isCollapsed ? (
-              <MenuIcon className="w-5 h-5 text-gray-600" />
-            ) : (
-              <ChevronLeftIcon className="w-5 h-5 text-gray-600" />
-            )}
-          </button>
-        </div>
-
+      <div 
+        className={`
+          flex flex-col bg-white border-r border-gray-200 transition-all duration-300 ease-in-out
+          ${!isHovering ? 'w-16' : 'w-64'}
+        `}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+      >
         {/* Navigation Items */}
-        <nav className="p-2">
+        <nav className="flex-1 p-2 pt-4">
           {navigationItems.map((item) => {
             const Icon = item.icon;
             const active = isActive(item.href);
@@ -111,18 +77,19 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={() => setIsHovering(false)}
                 className={`
                   flex items-center gap-3 px-3 py-3 rounded-lg mb-1 transition-all duration-200
                   ${active 
                     ? 'bg-primary text-white shadow-sm' 
                     : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
                   }
-                  ${isCollapsed ? 'justify-center' : ''}
+                  ${!isHovering ? 'justify-center' : ''}
                 `}
-                title={isCollapsed ? item.label : undefined}
+                title={!isHovering ? item.label : undefined}
               >
-                <Icon className={`flex-shrink-0 ${isCollapsed ? 'w-6 h-6' : 'w-5 h-5'}`} />
-                {!isCollapsed && (
+                <Icon className={`flex-shrink-0 ${!isHovering ? 'w-6 h-6' : 'w-5 h-5'}`} />
+                {isHovering && (
                   <span className="font-medium">{item.label}</span>
                 )}
               </Link>
@@ -131,8 +98,8 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
         </nav>
 
         {/* Footer */}
-        {!isCollapsed && (
-          <div className="absolute bottom-4 left-4 right-4">
+        {isHovering && (
+          <div className="mt-auto p-4">
             <div className="text-xs text-gray-500 text-center">
               AppliStash v1.0
             </div>


### PR DESCRIPTION
Introduces a reusable MainLayout component to centralize header, sidebar, and footer logic. Updates Contacts, Dashboard, and Interviews pages to use MainLayout, removing redundant sidebar/header/footer code and related state. Sidebar is refactored to use hover-based expansion instead of collapse state. This improves code maintainability and consistency across pages.